### PR TITLE
test: add auth, validation, and error handler middleware tests

### DIFF
--- a/tests/unit/auth.middleware.test.ts
+++ b/tests/unit/auth.middleware.test.ts
@@ -1,0 +1,190 @@
+// JWT_SECRET must be set before auth.middleware is imported because the module
+// throws at load time if the variable is missing. vi.stubEnv + dynamic import
+// is the correct Vitest pattern for this scenario.
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = 'test-secret-key';
+
+// Stub the env variable BEFORE the module is imported
+vi.stubEnv('JWT_SECRET', JWT_SECRET);
+
+// Dynamically import AFTER stubbing so the module-level guard sees the value
+const { authenticate, optionalAuthenticate, authorize } = await import(
+  '../../src/middleware/auth.middleware'
+);
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeToken(
+  payload: Record<string, unknown>,
+  expiresIn: string | number = '1h',
+): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn } as jwt.SignOptions);
+}
+
+function makeMocks() {
+  const req = { headers: {} } as Partial<Request>;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  } as Partial<Response>;
+  const next: NextFunction = vi.fn();
+  return { req, res, next };
+}
+
+// ── authenticate ──────────────────────────────────────────────────────────────
+
+describe('authenticate', () => {
+  it('calls next() and attaches user when token is valid', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = {
+      authorization: `Bearer ${makeToken({ id: 'user-1', email: 'a@b.com', role: 'learner' })}`,
+    };
+
+    authenticate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect((req as any).user).toMatchObject({ id: 'user-1', role: 'learner' });
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when Authorization header is missing', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = {};
+
+    authenticate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Authorization token required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when Authorization header does not start with Bearer', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = { authorization: 'Basic sometoken' };
+
+    authenticate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Authorization token required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 with "Token has expired" for an expired token', () => {
+    const { req, res, next } = makeMocks();
+    const token = makeToken({ id: 'u1', email: 'x@y.com', role: 'learner' }, -1);
+    req.headers = { authorization: `Bearer ${token}` };
+
+    authenticate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Token has expired' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 with "Invalid token" for a malformed token', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = { authorization: 'Bearer not.a.valid.token' };
+
+    authenticate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ── optionalAuthenticate ──────────────────────────────────────────────────────
+
+describe('optionalAuthenticate', () => {
+  it('calls next() without setting user when no token is provided', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = {};
+
+    optionalAuthenticate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect((req as any).user).toBeUndefined();
+  });
+
+  it('attaches user and calls next() when a valid token is provided', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = {
+      authorization: `Bearer ${makeToken({ id: 'user-2', email: 'b@c.com', role: 'employer' })}`,
+    };
+
+    optionalAuthenticate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect((req as any).user).toMatchObject({ id: 'user-2', role: 'employer' });
+  });
+
+  it('calls next() without blocking when token is invalid', () => {
+    const { req, res, next } = makeMocks();
+    req.headers = { authorization: 'Bearer bad.token.here' };
+
+    optionalAuthenticate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('calls next() without blocking when token is expired', () => {
+    const { req, res, next } = makeMocks();
+    const token = makeToken({ id: 'u1', email: 'x@y.com', role: 'learner' }, -1);
+    req.headers = { authorization: `Bearer ${token}` };
+
+    optionalAuthenticate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+// ── authorize ─────────────────────────────────────────────────────────────────
+
+describe('authorize', () => {
+  it('calls next() when user has a matching role', () => {
+    const { req, res, next } = makeMocks();
+    (req as any).user = { id: 'u1', email: 'a@b.com', role: 'learner' };
+
+    authorize('learner')(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when user role matches one of multiple allowed roles', () => {
+    const { req, res, next } = makeMocks();
+    (req as any).user = { id: 'u1', email: 'a@b.com', role: 'employer' };
+
+    authorize('learner', 'employer')(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('returns 403 when user role is not in the allowed list', () => {
+    const { req, res, next } = makeMocks();
+    (req as any).user = { id: 'u1', email: 'a@b.com', role: 'learner' };
+
+    authorize('employer')(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Access denied') }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when req.user is not set', () => {
+    const { req, res, next } = makeMocks();
+
+    authorize('learner')(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Authentication required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/errorHandler.test.ts
+++ b/tests/unit/errorHandler.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
+import { errorHandler } from '../../src/middleware/errorHandler';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeMocks() {
+  const req = {} as Request;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  } as Partial<Response>;
+  const next: NextFunction = vi.fn();
+  return { req, res, next };
+}
+
+// ── errorHandler ──────────────────────────────────────────────────────────────
+
+describe('errorHandler', () => {
+  it('uses err.status as the response status code', () => {
+    const { req, res, next } = makeMocks();
+    const err = { status: 404, message: 'Not found' };
+
+    errorHandler(err, req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Not found',
+    });
+  });
+
+  it('defaults to 500 when err.status is not set', () => {
+    const { req, res, next } = makeMocks();
+    const err = { message: 'Something went wrong' };
+
+    errorHandler(err, req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Something went wrong',
+    });
+  });
+
+  it('defaults to "Internal Server Error" when err.message is not set', () => {
+    const { req, res, next } = makeMocks();
+    const err = {};
+
+    errorHandler(err, req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Internal Server Error',
+    });
+  });
+
+  it('handles a native Error object', () => {
+    const { req, res, next } = makeMocks();
+    const err = new Error('Unexpected failure');
+
+    errorHandler(err, req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Unexpected failure',
+    });
+  });
+
+  it('always sets success: false in the response body', () => {
+    const { req, res, next } = makeMocks();
+
+    errorHandler({ status: 200, message: 'ok' }, req, res as Response, next);
+
+    const body = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(body.success).toBe(false);
+  });
+
+  it('handles a 400 bad request error', () => {
+    const { req, res, next } = makeMocks();
+    const err = { status: 400, message: 'Bad request' };
+
+    errorHandler(err, req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Bad request',
+    });
+  });
+
+  it('handles a 403 forbidden error', () => {
+    const { req, res, next } = makeMocks();
+    const err = { status: 403, message: 'Forbidden' };
+
+    errorHandler(err, req, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Forbidden',
+    });
+  });
+});

--- a/tests/unit/validation.middleware.test.ts
+++ b/tests/unit/validation.middleware.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
+import {
+  validateProfileUpdate,
+  validatePasswordChange,
+  validateWalletAddress,
+} from '../../src/middleware/validation.middleware';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeMocks(body: Record<string, any> = {}) {
+  const req = { body } as Partial<Request>;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  } as Partial<Response>;
+  const next: NextFunction = vi.fn();
+  return { req, res, next };
+}
+
+// ── validateProfileUpdate ─────────────────────────────────────────────────────
+
+describe('validateProfileUpdate', () => {
+  it('calls next() for a valid update payload', () => {
+    const { req, res, next } = makeMocks({
+      username: 'valid_user',
+      firstName: 'John',
+      lastName: 'Doe',
+      bio: 'Hello world',
+      avatar: 'https://example.com/avatar.jpg',
+    });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when body is empty (all fields optional)', () => {
+    const { req, res, next } = makeMocks({});
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('returns 400 when username is too short', () => {
+    const { req, res, next } = makeMocks({ username: 'ab' });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('3 characters')]) })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when username exceeds 30 characters', () => {
+    const { req, res, next } = makeMocks({ username: 'a'.repeat(31) });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('30 characters')]) })
+    );
+  });
+
+  it('returns 400 when username contains invalid characters', () => {
+    const { req, res, next } = makeMocks({ username: 'bad user!' });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('letters, numbers')]) })
+    );
+  });
+
+  it('returns 400 when firstName exceeds 50 characters', () => {
+    const { req, res, next } = makeMocks({ firstName: 'A'.repeat(51) });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('First name')]) })
+    );
+  });
+
+  it('returns 400 when lastName exceeds 50 characters', () => {
+    const { req, res, next } = makeMocks({ lastName: 'B'.repeat(51) });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('Last name')]) })
+    );
+  });
+
+  it('returns 400 when bio exceeds 500 characters', () => {
+    const { req, res, next } = makeMocks({ bio: 'x'.repeat(501) });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('Bio')]) })
+    );
+  });
+
+  it('returns 400 when avatar is not a valid URL', () => {
+    const { req, res, next } = makeMocks({ avatar: 'not-a-url' });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('valid URL')]) })
+    );
+  });
+
+  it('returns multiple errors when multiple fields are invalid', () => {
+    const { req, res, next } = makeMocks({
+      username: 'ab',
+      bio: 'x'.repeat(501),
+    });
+
+    validateProfileUpdate(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    const { errors } = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── validatePasswordChange ────────────────────────────────────────────────────
+
+describe('validatePasswordChange', () => {
+  it('calls next() for a valid password change', () => {
+    const { req, res, next } = makeMocks({
+      currentPassword: 'OldPass1!',
+      newPassword: 'NewPass1!',
+    });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when currentPassword is missing', () => {
+    const { req, res, next } = makeMocks({ newPassword: 'NewPass1!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('Current password')]) })
+    );
+  });
+
+  it('returns 400 when newPassword is missing', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'OldPass1!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('New password is required')]) })
+    );
+  });
+
+  it('returns 400 when newPassword is too short', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'OldPass1!', newPassword: 'Ab1!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('8 characters')]) })
+    );
+  });
+
+  it('returns 400 when newPassword has no lowercase letter', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'OldPass1!', newPassword: 'NEWPASS1!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('lowercase')]) })
+    );
+  });
+
+  it('returns 400 when newPassword has no uppercase letter', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'OldPass1!', newPassword: 'newpass1!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('uppercase')]) })
+    );
+  });
+
+  it('returns 400 when newPassword has no number', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'OldPass1!', newPassword: 'NewPassword!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('number')]) })
+    );
+  });
+
+  it('returns 400 when newPassword has no special character', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'OldPass1!', newPassword: 'NewPassword1' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('special character')]) })
+    );
+  });
+
+  it('returns 400 when newPassword is the same as currentPassword', () => {
+    const { req, res, next } = makeMocks({ currentPassword: 'SamePass1!', newPassword: 'SamePass1!' });
+
+    validatePasswordChange(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('different')]) })
+    );
+  });
+});
+
+// ── validateWalletAddress ─────────────────────────────────────────────────────
+
+describe('validateWalletAddress', () => {
+  const VALID_ADDRESS = 'G' + 'A'.repeat(55);
+
+  it('calls next() for a valid Stellar wallet address', () => {
+    const { req, res, next } = makeMocks({ walletAddress: VALID_ADDRESS });
+
+    validateWalletAddress(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when walletAddress is missing', () => {
+    const { req, res, next } = makeMocks({});
+
+    validateWalletAddress(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('required')]) })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when walletAddress does not start with G', () => {
+    const { req, res, next } = makeMocks({ walletAddress: 'X' + 'A'.repeat(55) });
+
+    validateWalletAddress(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('Invalid Stellar')]) })
+    );
+  });
+
+  it('returns 400 when walletAddress is too short', () => {
+    const { req, res, next } = makeMocks({ walletAddress: 'GABC123' });
+
+    validateWalletAddress(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('Invalid Stellar')]) })
+    );
+  });
+
+  it('returns 400 when walletAddress contains lowercase characters', () => {
+    const { req, res, next } = makeMocks({ walletAddress: 'g' + 'a'.repeat(55) });
+
+    validateWalletAddress(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: expect.arrayContaining([expect.stringContaining('Invalid Stellar')]) })
+    );
+  });
+
+  it('returns 400 when walletAddress is not a string', () => {
+    const { req, res, next } = makeMocks({ walletAddress: 12345 });
+
+    validateWalletAddress(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #26 

### Summary
Adds unit test coverage for three previously untested middleware modules.

### Tests added

### tests/unit/auth.middleware.test.ts — 13 tests

- authenticate: valid token, missing header, wrong scheme, expired token, malformed token
- optionalAuthenticate: no token, valid token, invalid token, expired token
- authorize: matching role, multiple allowed roles, wrong role (403), no user (401)

### tests/unit/validation.middleware.test.ts — 25 tests
- validateProfileUpdate: valid payload, empty body, username too short/long/invalid chars, firstName/lastName/bio too long, invalid avatar URL, multiple errors at once
- validatePasswordChange: valid change, missing current/new password, too short, missing lowercase/uppercase/number/special char, same as current
- validateWalletAddress: valid address, missing, wrong prefix, too short, lowercase, non-string

### tests/unit/errorHandler.test.ts — 7 tests
- Uses err.status as response code, defaults to 500, defaults message to "Internal Server Error", handles native Error objects, always sets success: false, 400 and 403 error codes