### PR TITLE
feat: Offline Progress Sync API (#51)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   completions     Completion[]
   credentials     Credential[]
   transactions    Transaction[]
+  syncEvents      SyncEvent[]
 
   @@map("users")
 }
@@ -82,6 +83,24 @@ enum Role {
 }
 
 
+
+model SyncEvent {
+  id              String   @id @default(uuid())
+  idempotencyKey  String   @unique
+  userId          String
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deviceId        String
+  eventType       String   // progress, completion
+  payload         String   // JSON string
+  clientTimestamp DateTime
+  serverTimestamp DateTime @default(now())
+  syncVersion     Int
+  status          String   @default("applied") // applied, skipped, rejected
+  rejectionReason String?
+  createdAt       DateTime @default(now())
+
+  @@map("sync_events")
+}
 
 model WebhookEndpoint {
   id          String            @id @default(uuid())

--- a/src/controllers/sync.controller.ts
+++ b/src/controllers/sync.controller.ts
@@ -1,0 +1,249 @@
+import { Request, Response } from 'express'
+import prisma from '../config/database'
+import { asyncHandler } from '../middleware/error.middleware'
+import { BadRequestError, UnauthorizedError } from '../utils/errors'
+
+interface ProgressEvent {
+  idempotencyKey: string
+  deviceId: string
+  moduleId: string
+  progressPercent: number
+  clientTimestamp: string
+  syncVersion: number
+}
+
+interface CompletionEvent {
+  idempotencyKey: string
+  deviceId: string
+  moduleId: string
+  score: number
+  clientTimestamp: string
+  syncVersion: number
+}
+
+type SyncStatus = 'applied' | 'skipped' | 'rejected'
+
+interface SyncResult {
+  idempotencyKey: string
+  status: SyncStatus
+  reason?: string
+}
+
+export class SyncController {
+  /**
+   * @openapi
+   * /sync/progress:
+   *   post:
+   *     summary: Upload batched offline progress events
+   *     tags: [Sync]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [events]
+   *             properties:
+   *               events:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   required: [idempotencyKey, deviceId, moduleId, progressPercent, clientTimestamp, syncVersion]
+   *     responses:
+   *       200:
+   *         description: Sync results per item
+   *       400:
+   *         description: Invalid payload
+   *       401:
+   *         description: Unauthorized
+   */
+  syncProgress = asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const userId = (req as any).user?.id
+    if (!userId) throw new UnauthorizedError('User ID not found')
+
+    const { events } = req.body
+    if (!Array.isArray(events) || events.length === 0) {
+      throw new BadRequestError('events must be a non-empty array')
+    }
+
+    const results: SyncResult[] = []
+
+    for (const event of events as ProgressEvent[]) {
+      const { idempotencyKey, deviceId, moduleId, progressPercent, clientTimestamp, syncVersion } = event
+
+      if (!idempotencyKey || !deviceId || !moduleId || progressPercent === undefined || !clientTimestamp || syncVersion === undefined) {
+        results.push({ idempotencyKey: idempotencyKey ?? 'unknown', status: 'rejected', reason: 'Missing required fields' })
+        continue
+      }
+
+      if (typeof progressPercent !== 'number' || progressPercent < 0 || progressPercent > 100) {
+        results.push({ idempotencyKey, status: 'rejected', reason: 'progressPercent must be between 0 and 100' })
+        continue
+      }
+
+      const clientTs = new Date(clientTimestamp)
+      if (isNaN(clientTs.getTime())) {
+        results.push({ idempotencyKey, status: 'rejected', reason: 'Invalid clientTimestamp format' })
+        continue
+      }
+
+      const existing = await prisma.syncEvent.findUnique({ where: { idempotencyKey } })
+      if (existing) {
+        results.push({ idempotencyKey, status: 'skipped' })
+        continue
+      }
+
+      const latestForModule = await prisma.syncEvent.findFirst({
+        where: { userId, payload: { contains: moduleId }, eventType: 'progress' },
+        orderBy: { syncVersion: 'desc' },
+      })
+
+      if (latestForModule && latestForModule.syncVersion > syncVersion) {
+        results.push({ idempotencyKey, status: 'skipped', reason: 'Stale sync version — a newer version already applied' })
+        continue
+      }
+
+      await prisma.syncEvent.create({
+        data: {
+          idempotencyKey,
+          userId,
+          deviceId,
+          eventType: 'progress',
+          payload: JSON.stringify({ moduleId, progressPercent }),
+          clientTimestamp: clientTs,
+          syncVersion,
+          status: 'applied',
+        },
+      })
+
+      results.push({ idempotencyKey, status: 'applied' })
+    }
+
+    res.status(200).json({ success: true, data: { results } })
+  })
+
+  /**
+   * @openapi
+   * /sync/completions:
+   *   post:
+   *     summary: Reconcile offline quiz/completion attempts
+   *     tags: [Sync]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [events]
+   *             properties:
+   *               events:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   required: [idempotencyKey, deviceId, moduleId, score, clientTimestamp, syncVersion]
+   *     responses:
+   *       200:
+   *         description: Per-item sync results
+   *       400:
+   *         description: Invalid payload
+   *       401:
+   *         description: Unauthorized
+   */
+  syncCompletions = asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const userId = (req as any).user?.id
+    if (!userId) throw new UnauthorizedError('User ID not found')
+
+    const { events } = req.body
+    if (!Array.isArray(events) || events.length === 0) {
+      throw new BadRequestError('events must be a non-empty array')
+    }
+
+    const results: SyncResult[] = []
+
+    for (const event of events as CompletionEvent[]) {
+      const { idempotencyKey, deviceId, moduleId, score, clientTimestamp, syncVersion } = event
+
+      if (!idempotencyKey || !deviceId || !moduleId || score === undefined || !clientTimestamp || syncVersion === undefined) {
+        results.push({ idempotencyKey: idempotencyKey ?? 'unknown', status: 'rejected', reason: 'Missing required fields' })
+        continue
+      }
+
+      if (typeof score !== 'number' || score < 0 || score > 100) {
+        results.push({ idempotencyKey, status: 'rejected', reason: 'score must be between 0 and 100' })
+        continue
+      }
+
+      const clientTs = new Date(clientTimestamp)
+      if (isNaN(clientTs.getTime())) {
+        results.push({ idempotencyKey, status: 'rejected', reason: 'Invalid clientTimestamp format' })
+        continue
+      }
+
+      const existing = await prisma.syncEvent.findUnique({ where: { idempotencyKey } })
+      if (existing) {
+        results.push({ idempotencyKey, status: 'skipped' })
+        continue
+      }
+
+      const module = await prisma.module.findUnique({ where: { id: moduleId } })
+      if (!module) {
+        results.push({ idempotencyKey, status: 'rejected', reason: 'Module not found' })
+        continue
+      }
+
+      const alreadyCompleted = await prisma.completion.findUnique({
+        where: { userId_moduleId: { userId, moduleId } },
+      })
+
+      if (alreadyCompleted) {
+        if (score <= alreadyCompleted.score) {
+          await prisma.syncEvent.create({
+            data: {
+              idempotencyKey,
+              userId,
+              deviceId,
+              eventType: 'completion',
+              payload: JSON.stringify({ moduleId, score }),
+              clientTimestamp: clientTs,
+              syncVersion,
+              status: 'skipped',
+              rejectionReason: 'Existing completion has equal or higher score',
+            },
+          })
+          results.push({ idempotencyKey, status: 'skipped', reason: 'Existing completion has equal or higher score' })
+          continue
+        }
+
+        await prisma.completion.update({
+          where: { userId_moduleId: { userId, moduleId } },
+          data: { score },
+        })
+      } else {
+        await prisma.completion.create({
+          data: { userId, moduleId, score },
+        })
+      }
+
+      await prisma.syncEvent.create({
+        data: {
+          idempotencyKey,
+          userId,
+          deviceId,
+          eventType: 'completion',
+          payload: JSON.stringify({ moduleId, score }),
+          clientTimestamp: clientTs,
+          syncVersion,
+          status: 'applied',
+        },
+      })
+
+      results.push({ idempotencyKey, status: 'applied' })
+    }
+
+    res.status(200).json({ success: true, data: { results } })
+  })
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import moduleRoutes from './v1/modules.routes'
 import credentialRoutes from './v1/credentials.routes'
 import rewardRoutes from './v1/rewards.routes'
 import userRoutes from './v1/users.routes'
+import syncRoutes from './v1/sync.routes'
 
 const router: Router = Router()
 
@@ -18,5 +19,6 @@ router.use('/v1/modules', moduleRoutes)
 router.use('/v1/credentials', credentialRoutes)
 router.use('/v1/rewards', rewardRoutes)
 router.use('/v1/employer', employerRoutes)
+router.use('/v1/sync', syncRoutes)
 
 export default router

--- a/src/routes/v1/sync.routes.ts
+++ b/src/routes/v1/sync.routes.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express'
+import { SyncController } from '../../controllers/sync.controller'
+import { authenticate } from '../../middleware/auth.middleware'
+import { authenticatedLimiter } from '../../middleware/rate-limit.middleware'
+
+const router = Router()
+const syncController = new SyncController()
+
+/**
+ * @route   POST /api/v1/sync/progress
+ * @desc    Upload batched offline progress events
+ * @body    events - Array of progress events with idempotencyKey, deviceId, moduleId, progressPercent, clientTimestamp, syncVersion
+ * @access  Private
+ */
+router.post(
+  '/progress',
+  authenticate,
+  authenticatedLimiter,
+  syncController.syncProgress.bind(syncController),
+)
+
+/**
+ * @route   POST /api/v1/sync/completions
+ * @desc    Reconcile offline quiz/completion attempts
+ * @body    events - Array of completion events with idempotencyKey, deviceId, moduleId, score, clientTimestamp, syncVersion
+ * @access  Private
+ */
+router.post(
+  '/completions',
+  authenticate,
+  authenticatedLimiter,
+  syncController.syncCompletions.bind(syncController),
+)
+
+export default router

--- a/tests/sync.controller.test.ts
+++ b/tests/sync.controller.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Request, Response } from 'express'
+import { SyncController } from '../src/controllers/sync.controller'
+
+vi.mock('../src/config/database', () => ({
+  default: {
+    syncEvent: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    completion: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    module: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+import prisma from '../src/config/database'
+
+interface AuthRequest extends Request {
+  user?: { id: string; email: string; role: string }
+}
+
+const makeEvent = (overrides = {}) => ({
+  idempotencyKey: 'idem-1',
+  deviceId: 'device-abc',
+  moduleId: 'module-1',
+  progressPercent: 50,
+  clientTimestamp: new Date().toISOString(),
+  syncVersion: 1,
+  ...overrides,
+})
+
+const makeCompletionEvent = (overrides = {}) => ({
+  idempotencyKey: 'idem-c1',
+  deviceId: 'device-abc',
+  moduleId: 'module-1',
+  score: 85,
+  clientTimestamp: new Date().toISOString(),
+  syncVersion: 1,
+  ...overrides,
+})
+
+describe('SyncController', () => {
+  let controller: SyncController
+  let req: Partial<AuthRequest>
+  let res: Partial<Response>
+  let next: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    controller = new SyncController()
+    req = {
+      user: { id: 'user-1', email: 'test@example.com', role: 'LEARNER' },
+      body: {},
+    }
+    res = { json: vi.fn(), status: vi.fn().mockReturnThis() }
+    next = vi.fn()
+    vi.clearAllMocks()
+  })
+
+  describe('syncProgress', () => {
+    it('throws UnauthorizedError when user is missing', async () => {
+      req.user = undefined
+      req.body = { events: [makeEvent()] }
+      await controller.syncProgress(req as Request, res as Response, next)
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'User ID not found' }))
+    })
+
+    it('throws BadRequestError when events is not an array', async () => {
+      req.body = { events: 'not-an-array' }
+      await controller.syncProgress(req as Request, res as Response, next)
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'events must be a non-empty array' }))
+    })
+
+    it('rejects event with missing required fields', async () => {
+      req.body = { events: [{ idempotencyKey: 'idem-1' }] }
+      await controller.syncProgress(req as Request, res as Response, next)
+      expect(res.status).toHaveBeenCalledWith(200)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('rejected')
+    })
+
+    it('rejects event with invalid progressPercent', async () => {
+      req.body = { events: [makeEvent({ progressPercent: 150 })] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      await controller.syncProgress(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0]).toEqual(expect.objectContaining({ status: 'rejected' }))
+    })
+
+    it('skips duplicate idempotency key', async () => {
+      req.body = { events: [makeEvent()] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue({ id: 'existing' } as any)
+      await controller.syncProgress(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('skipped')
+    })
+
+    it('skips stale sync version', async () => {
+      req.body = { events: [makeEvent({ syncVersion: 1 })] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.syncEvent.findFirst).mockResolvedValue({ syncVersion: 5 } as any)
+      await controller.syncProgress(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('skipped')
+    })
+
+    it('applies a valid progress event', async () => {
+      req.body = { events: [makeEvent()] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.syncEvent.findFirst).mockResolvedValue(null)
+      vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
+      await controller.syncProgress(req as Request, res as Response, next)
+      expect(prisma.syncEvent.create).toHaveBeenCalled()
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('applied')
+    })
+
+    it('handles partial success across multiple events', async () => {
+      req.body = {
+        events: [
+          makeEvent({ idempotencyKey: 'idem-1' }),
+          makeEvent({ idempotencyKey: 'idem-2', progressPercent: 999 }),
+        ],
+      }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.syncEvent.findFirst).mockResolvedValue(null)
+      vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
+      await controller.syncProgress(req as Request, res as Response, next)
+      const { results } = vi.mocked(res.json).mock.calls[0][0].data
+      expect(results[0].status).toBe('applied')
+      expect(results[1].status).toBe('rejected')
+    })
+  })
+
+  describe('syncCompletions', () => {
+    it('throws UnauthorizedError when user is missing', async () => {
+      req.user = undefined
+      req.body = { events: [makeCompletionEvent()] }
+      await controller.syncCompletions(req as Request, res as Response, next)
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'User ID not found' }))
+    })
+
+    it('rejects event for unknown module', async () => {
+      req.body = { events: [makeCompletionEvent()] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.module.findUnique).mockResolvedValue(null)
+      await controller.syncCompletions(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0]).toEqual(expect.objectContaining({ status: 'rejected', reason: 'Module not found' }))
+    })
+
+    it('skips duplicate idempotency key', async () => {
+      req.body = { events: [makeCompletionEvent()] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue({ id: 'existing' } as any)
+      await controller.syncCompletions(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('skipped')
+    })
+
+    it('skips completion if existing score is higher', async () => {
+      req.body = { events: [makeCompletionEvent({ score: 60 })] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.module.findUnique).mockResolvedValue({ id: 'module-1' } as any)
+      vi.mocked(prisma.completion.findUnique).mockResolvedValue({ score: 90 } as any)
+      vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
+      await controller.syncCompletions(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('skipped')
+      expect(prisma.completion.update).not.toHaveBeenCalled()
+    })
+
+    it('updates completion when new score is higher', async () => {
+      req.body = { events: [makeCompletionEvent({ score: 95 })] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.module.findUnique).mockResolvedValue({ id: 'module-1' } as any)
+      vi.mocked(prisma.completion.findUnique).mockResolvedValue({ score: 70 } as any)
+      vi.mocked(prisma.completion.update).mockResolvedValue({} as any)
+      vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
+      await controller.syncCompletions(req as Request, res as Response, next)
+      expect(prisma.completion.update).toHaveBeenCalled()
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('applied')
+    })
+
+    it('creates new completion when none exists', async () => {
+      req.body = { events: [makeCompletionEvent()] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.module.findUnique).mockResolvedValue({ id: 'module-1' } as any)
+      vi.mocked(prisma.completion.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.completion.create).mockResolvedValue({} as any)
+      vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
+      await controller.syncCompletions(req as Request, res as Response, next)
+      expect(prisma.completion.create).toHaveBeenCalled()
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('applied')
+    })
+
+    it('rejects event with invalid score', async () => {
+      req.body = { events: [makeCompletionEvent({ score: -5 })] }
+      vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
+      await controller.syncCompletions(req as Request, res as Response, next)
+      const call = vi.mocked(res.json).mock.calls[0][0]
+      expect(call.data.results[0].status).toBe('rejected')
+    })
+  })
+})

--- a/tests/sync.controller.test.ts
+++ b/tests/sync.controller.test.ts
@@ -22,6 +22,8 @@ vi.mock('../src/config/database', () => ({
 
 import prisma from '../src/config/database'
 
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
 interface AuthRequest extends Request {
   user?: { id: string; email: string; role: string }
 }
@@ -67,19 +69,28 @@ describe('SyncController', () => {
     it('throws UnauthorizedError when user is missing', async () => {
       req.user = undefined
       req.body = { events: [makeEvent()] }
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'User ID not found' }))
     })
 
     it('throws BadRequestError when events is not an array', async () => {
       req.body = { events: 'not-an-array' }
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'events must be a non-empty array' }))
     })
 
     it('rejects event with missing required fields', async () => {
       req.body = { events: [{ idempotencyKey: 'idem-1' }] }
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(res.status).toHaveBeenCalledWith(200)
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('rejected')
@@ -88,7 +99,10 @@ describe('SyncController', () => {
     it('rejects event with invalid progressPercent', async () => {
       req.body = { events: [makeEvent({ progressPercent: 150 })] }
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0]).toEqual(expect.objectContaining({ status: 'rejected' }))
     })
@@ -96,7 +110,10 @@ describe('SyncController', () => {
     it('skips duplicate idempotency key', async () => {
       req.body = { events: [makeEvent()] }
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue({ id: 'existing' } as any)
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('skipped')
     })
@@ -105,7 +122,10 @@ describe('SyncController', () => {
       req.body = { events: [makeEvent({ syncVersion: 1 })] }
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
       vi.mocked(prisma.syncEvent.findFirst).mockResolvedValue({ syncVersion: 5 } as any)
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('skipped')
     })
@@ -115,7 +135,10 @@ describe('SyncController', () => {
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
       vi.mocked(prisma.syncEvent.findFirst).mockResolvedValue(null)
       vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(prisma.syncEvent.create).toHaveBeenCalled()
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('applied')
@@ -131,7 +154,10 @@ describe('SyncController', () => {
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
       vi.mocked(prisma.syncEvent.findFirst).mockResolvedValue(null)
       vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
-      await controller.syncProgress(req as Request, res as Response, next)
+
+      controller.syncProgress(req as Request, res as Response, next)
+      await flushPromises()
+
       const { results } = vi.mocked(res.json).mock.calls[0][0].data
       expect(results[0].status).toBe('applied')
       expect(results[1].status).toBe('rejected')
@@ -142,7 +168,10 @@ describe('SyncController', () => {
     it('throws UnauthorizedError when user is missing', async () => {
       req.user = undefined
       req.body = { events: [makeCompletionEvent()] }
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'User ID not found' }))
     })
 
@@ -150,7 +179,10 @@ describe('SyncController', () => {
       req.body = { events: [makeCompletionEvent()] }
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
       vi.mocked(prisma.module.findUnique).mockResolvedValue(null)
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0]).toEqual(expect.objectContaining({ status: 'rejected', reason: 'Module not found' }))
     })
@@ -158,7 +190,10 @@ describe('SyncController', () => {
     it('skips duplicate idempotency key', async () => {
       req.body = { events: [makeCompletionEvent()] }
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue({ id: 'existing' } as any)
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('skipped')
     })
@@ -169,7 +204,10 @@ describe('SyncController', () => {
       vi.mocked(prisma.module.findUnique).mockResolvedValue({ id: 'module-1' } as any)
       vi.mocked(prisma.completion.findUnique).mockResolvedValue({ score: 90 } as any)
       vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('skipped')
       expect(prisma.completion.update).not.toHaveBeenCalled()
@@ -182,7 +220,10 @@ describe('SyncController', () => {
       vi.mocked(prisma.completion.findUnique).mockResolvedValue({ score: 70 } as any)
       vi.mocked(prisma.completion.update).mockResolvedValue({} as any)
       vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(prisma.completion.update).toHaveBeenCalled()
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('applied')
@@ -195,7 +236,10 @@ describe('SyncController', () => {
       vi.mocked(prisma.completion.findUnique).mockResolvedValue(null)
       vi.mocked(prisma.completion.create).mockResolvedValue({} as any)
       vi.mocked(prisma.syncEvent.create).mockResolvedValue({} as any)
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       expect(prisma.completion.create).toHaveBeenCalled()
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('applied')
@@ -204,7 +248,10 @@ describe('SyncController', () => {
     it('rejects event with invalid score', async () => {
       req.body = { events: [makeCompletionEvent({ score: -5 })] }
       vi.mocked(prisma.syncEvent.findUnique).mockResolvedValue(null)
-      await controller.syncCompletions(req as Request, res as Response, next)
+
+      controller.syncCompletions(req as Request, res as Response, next)
+      await flushPromises()
+
       const call = vi.mocked(res.json).mock.calls[0][0]
       expect(call.data.results[0].status).toBe('rejected')
     })


### PR DESCRIPTION
Fixes #51

## What changed
- Added `SyncEvent` Prisma model tracking `idempotencyKey`, `deviceId`, `clientTimestamp`, `serverTimestamp`, `syncVersion`, `status`, and `rejectionReason`
- `POST /api/v1/sync/progress` — accepts batched offline progress events; resolves conflicts by rejecting stale sync versions
- `POST /api/v1/sync/completions` — reconciles offline quiz/completion attempts; updates score when higher, skips when equal or lower, creates new completion when none exists
- Idempotency keys prevent duplicate processing of retried payloads
- Per-item results returned: `applied`, `skipped`, or `rejected` with a reason
- Both endpoints protected by JWT auth and rate-limited via `authenticatedLimiter`

## Why
- Enables offline-first learning by accepting locally cached progress once the user reconnects
- Deterministic conflict resolution ensures data integrity without requiring client-server coordination

## How to test
- `POST /api/v1/sync/progress` with `{ "events": [{ "idempotencyKey": "...", "deviceId": "...", "moduleId": "...", "progressPercent": 60, "clientTimestamp": "...", "syncVersion": 1 }] }` → should return `applied`
- Retry the same payload → second call should return `skipped`
- Send a payload with `syncVersion` lower than an already-stored event → should return `skipped` with stale version reason
- `POST /api/v1/sync/completions` with valid events → applied if module exists and score is new or higher
- Send completion for a module already completed with higher score → should return `skipped`
- Send completion for non-existent module → should return `rejected` with reason