### PR TITLE
feat(api): add secure auth token, session, and login attempt persistence

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,6 +6,37 @@ datasource db {
   provider = "postgresql"
 }
 
+enum TokenPurpose {
+  EMAIL_VERIFICATION
+  PASSWORD_RESET
+}
+
+enum TokenStatus {
+  PENDING
+  USED
+  REVOKED
+  EXPIRED
+}
+
+enum SessionStatus {
+  ACTIVE
+  REVOKED
+  EXPIRED
+}
+
+enum LoginAttemptStatus {
+  SUCCESS
+  FAILURE
+  LOCKED
+}
+
+enum AccountStatus {
+  ACTIVE
+  DEACTIVATED
+  PENDING_DELETION
+  DELETED
+}
+
 model User {
   id              String         @id @default(uuid())
   email           String         @unique
@@ -16,7 +47,7 @@ model User {
   isVerified      Boolean        @default(false)
   phone           String?        @unique
   phoneVerifiedAt DateTime?
-  status          String         @default("ACTIVE") // ACTIVE, DEACTIVATED, PENDING_DELETION, DELETED
+  status          AccountStatus  @default(ACTIVE)
   statusChangedAt DateTime?
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
@@ -35,11 +66,12 @@ model User {
   emailDeliveries EmailDelivery[]
   learnerPreference LearnerPreference?
   preferenceAuditLogs PreferenceAuditLog[]
-  sessions        Session[]
+  sessions        RefreshSession[]
   audits          AuditLog[]
   dataExports     DataExportRequest[]
   deletionRequests AccountDeletionRequest[]
   otpChallenges   OtpChallenge[]
+  loginAttempts   LoginAttempt[]
 
   @@map("users")
 }
@@ -49,25 +81,20 @@ model LearnerPreference {
   userId              String   @unique
   user                User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  // Locale & regional
   locale              String   @default("en-US")
   timezone            String   @default("UTC")
 
-  // Connectivity
   lowDataMode         Boolean  @default(false)
 
-  // Accessibility
   highContrast        Boolean  @default(false)
   reduceMotion        Boolean  @default(false)
   screenReaderOptimized Boolean @default(false)
-  textSize            String   @default("medium") // small, medium, large, extra_large
+  textSize            String   @default("medium")
 
-  // Content
-  preferredDifficulty String   @default("beginner") // beginner, intermediate, advanced
+  preferredDifficulty String   @default("beginner")
   preferredCategories String[] @default([])
 
-  // Privacy (authoritative source for privacy-impacting preferences)
-  profileVisibility   String   @default("public") // public, private, connections
+  profileVisibility   String   @default("public")
   analyticsConsent    Boolean  @default(false)
   dataSharingConsent  Boolean  @default(false)
 
@@ -90,30 +117,35 @@ model PreferenceAuditLog {
   @@map("preference_audit_logs")
 }
 
-model Session {
-  id           String    @id @default(uuid())
-  userId       String
-  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  token        String    @unique
-  refreshToken String?   @unique
-  userAgent    String?
-  ipAddress    String?
-  expiresAt    DateTime
-  isRevoked    Boolean   @default(false)
-  revokedAt    DateTime?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+model RefreshSession {
+  id             String        @id @default(uuid())
+  userId         String
+  user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash      String        @unique
+  tokenFamily    String
+  userAgent      String?
+  ipAddress      String?
+  deviceId         String?
+  deviceName     String?
+  status         SessionStatus @default(ACTIVE)
+  expiresAt      DateTime
+  lastUsedAt    DateTime     @default(now())
+  revokedAt      DateTime?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  @@index([userId, isRevoked])
-  @@map("sessions")
+  @@index([userId, status])
+  @@index([tokenFamily])
+  @@index([expiresAt])
+  @@map("refresh_sessions")
 }
 
 model AuditLog {
   id        String   @id @default(uuid())
   userId    String?
   user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
-  action    String   // "PASSWORD_RESET", "EMAIL_VERIFIED", "LOGIN", etc.
-  metadata  String?  // JSON string for additional details (without secrets)
+  action    String
+  metadata  String?
   ipAddress String?
   userAgent String?
   createdAt DateTime @default(now())
@@ -123,18 +155,36 @@ model AuditLog {
 }
 
 model VerificationToken {
-  id        String   @id @default(uuid())
+  id        String         @id @default(uuid())
   userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   tokenHash String
-  type      String   @default("EMAIL_VERIFICATION")
-  status    String   @default("PENDING") // PENDING, USED, REVOKED
+  purpose   TokenPurpose
+  status    TokenStatus    @default(PENDING)
   expiresAt DateTime
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  usedAt    DateTime?
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
 
-  @@index([userId, status])
+  @@index([userId, purpose, status])
+  @@index([expiresAt])
   @@map("verification_tokens")
+}
+
+model LoginAttempt {
+  id           String           @id @default(uuid())
+  userId       String
+  user         User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  email        String
+  ipAddress    String?
+  userAgent    String?
+  status       LoginAttemptStatus
+  failureReason String?
+  createdAt    DateTime         @default(now())
+
+  @@index([userId, createdAt])
+  @@index([email, createdAt])
+  @@map("login_attempts")
 }
 
 model EmailDelivery {

--- a/src/domain/auth/index.ts
+++ b/src/domain/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './token.service'
+export * from './refresh-session.service'
+export * from './login-attempt.service'

--- a/src/domain/auth/login-attempt.service.ts
+++ b/src/domain/auth/login-attempt.service.ts
@@ -1,0 +1,50 @@
+import prisma from '../../config/database'
+import type { LoginAttemptStatus } from '@prisma/client'
+
+export const LOGIN_LOCKOUT_THRESHOLD = 5
+export const LOGIN_LOCKOUT_WINDOW_MS = 15 * 60 * 1000
+
+export class LoginAttemptService {
+  async recordAttempt(
+    userId: string,
+    email: string,
+    status: LoginAttemptStatus,
+    options: { ipAddress?: string; userAgent?: string; failureReason?: string } = {}
+  ): Promise<void> {
+    await prisma.loginAttempt.create({
+      data: {
+        userId,
+        email,
+        status,
+        ipAddress: options.ipAddress,
+        userAgent: options.userAgent,
+        failureReason: options.failureReason
+      }
+    })
+  }
+
+  async getRecentFailedAttempts(
+    email: string,
+    windowMs: number = LOGIN_LOCKOUT_WINDOW_MS
+  ): Promise<number> {
+    const since = new Date(Date.now() - windowMs)
+    return prisma.loginAttempt.count({
+      where: {
+        email,
+        status: 'FAILURE',
+        createdAt: { gte: since }
+      }
+    })
+  }
+
+  async isLockedOut(
+    email: string,
+    threshold: number = LOGIN_LOCKOUT_THRESHOLD,
+    windowMs: number = LOGIN_LOCKOUT_WINDOW_MS
+  ): Promise<boolean> {
+    const failedCount = await this.getRecentFailedAttempts(email, windowMs)
+    return failedCount >= threshold
+  }
+}
+
+export const loginAttemptService = new LoginAttemptService()

--- a/src/domain/auth/refresh-session.service.ts
+++ b/src/domain/auth/refresh-session.service.ts
@@ -1,0 +1,163 @@
+import crypto from 'crypto'
+import prisma from '../../config/database'
+import type { SessionStatus } from '@prisma/client'
+import { generateRawToken, hashToken } from './token.service'
+
+export const REFRESH_TOKEN_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000
+export const TOKEN_FAMILY_LENGTH = 16
+
+function generateTokenFamily(): string {
+  return crypto.randomBytes(TOKEN_FAMILY_LENGTH).toString('hex')
+}
+
+export class RefreshSessionService {
+  async createSession(
+    userId: string,
+    options: {
+      userAgent?: string
+      ipAddress?: string
+      deviceId?: string
+      deviceName?: string
+    } = {}
+  ): Promise<{ rawToken: string; sessionId: string }> {
+    const rawToken = generateRawToken()
+    const tokenHash = hashToken(rawToken)
+    const tokenFamily = generateTokenFamily()
+    const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS)
+
+    const session = await prisma.refreshSession.create({
+      data: {
+        userId,
+        tokenHash,
+        tokenFamily,
+        userAgent: options.userAgent,
+        ipAddress: options.ipAddress,
+        deviceId: options.deviceId,
+        deviceName: options.deviceName,
+        expiresAt
+      }
+    })
+
+    return { rawToken, sessionId: session.id }
+  }
+
+  async rotateSession(
+    rawToken: string,
+    options: {
+      userAgent?: string
+      ipAddress?: string
+    } = {}
+  ): Promise<
+    | { ok: true; newRawToken: string; newSessionId: string; userId: string }
+    | { ok: false; reason: 'invalid' | 'expired' | 'revoked' }
+  > {
+    const tokenHash = hashToken(rawToken)
+    const session = await prisma.refreshSession.findFirst({
+      where: { tokenHash }
+    })
+
+    if (!session) {
+      return { ok: false, reason: 'invalid' }
+    }
+
+    if (session.status !== 'ACTIVE') {
+      const reason: any = session.status.toLowerCase()
+      return { ok: false, reason }
+    }
+
+    if (new Date() > session.expiresAt) {
+      await prisma.refreshSession.update({
+        where: { id: session.id },
+        data: { status: 'EXPIRED' }
+      })
+      return { ok: false, reason: 'expired' }
+    }
+
+    await prisma.refreshSession.update({
+      where: { id: session.id },
+      data: { status: 'REVOKED', revokedAt: new Date() }
+    })
+
+    await prisma.refreshSession.updateMany({
+      where: {
+        tokenFamily: session.tokenFamily,
+        id: { not: session.id },
+        status: 'ACTIVE'
+      },
+      data: { status: 'REVOKED', revokedAt: new Date() }
+    })
+
+    const newRawToken = generateRawToken()
+    const newTokenHash = hashToken(newRawToken)
+    const newExpiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS)
+
+    const newSession = await prisma.refreshSession.create({
+      data: {
+        userId: session.userId,
+        tokenHash: newTokenHash,
+        tokenFamily: session.tokenFamily,
+        userAgent: options.userAgent ?? session.userAgent,
+        ipAddress: options.ipAddress ?? session.ipAddress,
+        deviceId: session.deviceId,
+        deviceName: session.deviceName,
+        expiresAt: newExpiresAt
+      }
+    })
+
+    return {
+      ok: true,
+      newRawToken,
+      newSessionId: newSession.id,
+      userId: session.userId
+    }
+  }
+
+  async getSessionByToken(
+    rawToken: string
+  ): Promise<{ id: string; userId: string; status: SessionStatus } | null> {
+    const tokenHash = hashToken(rawToken)
+    const session = await prisma.refreshSession.findFirst({
+      where: { tokenHash },
+      select: { id: true, userId: true, status: true }
+    })
+    return session
+  }
+
+  async getSessionsForUser(
+    userId: string,
+    options: { includeRevoked?: boolean } = {}
+  ) {
+    return prisma.refreshSession.findMany({
+      where: {
+        userId,
+        ...(options.includeRevoked
+          ? {}
+          : { status: 'ACTIVE' })
+      },
+      orderBy: { createdAt: 'desc' }
+    })
+  }
+
+  async revokeSession(sessionId: string): Promise<void> {
+    await prisma.refreshSession.update({
+      where: { id: sessionId },
+      data: { status: 'REVOKED', revokedAt: new Date() }
+    })
+  }
+
+  async revokeAllSessionsForUser(userId: string): Promise<void> {
+    await prisma.refreshSession.updateMany({
+      where: { userId, status: 'ACTIVE' },
+      data: { status: 'REVOKED', revokedAt: new Date() }
+    })
+  }
+
+  async revokeSessionsByFamily(tokenFamily: string): Promise<void> {
+    await prisma.refreshSession.updateMany({
+      where: { tokenFamily, status: 'ACTIVE' },
+      data: { status: 'REVOKED', revokedAt: new Date() }
+    })
+  }
+}
+
+export const refreshSessionService = new RefreshSessionService()

--- a/src/domain/auth/token.service.ts
+++ b/src/domain/auth/token.service.ts
@@ -1,0 +1,101 @@
+import crypto from 'crypto'
+import prisma from '../../config/database'
+import type { TokenPurpose, TokenStatus } from '@prisma/client'
+
+export const TOKEN_LENGTH = 32
+export const EMAIL_VERIFICATION_EXPIRY_MS = 24 * 60 * 60 * 1000
+export const PASSWORD_RESET_EXPIRY_MS = 60 * 60 * 1000
+
+export function generateRawToken(): string {
+  return crypto.randomBytes(TOKEN_LENGTH).toString('hex')
+}
+
+export function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex')
+}
+
+export class TokenService {
+  async createToken(
+    userId: string,
+    purpose: TokenPurpose
+  ): Promise<{ rawToken: string; tokenId: string }> {
+    await prisma.verificationToken.updateMany({
+      where: { userId, purpose, status: 'PENDING' },
+      data: { status: 'REVOKED' }
+    })
+
+    const rawToken = generateRawToken()
+    const tokenHash = hashToken(rawToken)
+    const now = Date.now()
+    const expiryMs =
+      purpose === 'EMAIL_VERIFICATION'
+        ? EMAIL_VERIFICATION_EXPIRY_MS
+        : PASSWORD_RESET_EXPIRY_MS
+
+    const token = await prisma.verificationToken.create({
+      data: {
+        userId,
+        tokenHash,
+        purpose,
+        expiresAt: new Date(now + expiryMs)
+      }
+    })
+
+    return { rawToken, tokenId: token.id }
+  }
+
+  async verifyToken(
+    rawToken: string,
+    purpose: TokenPurpose
+  ): Promise<
+    | { ok: true; userId: string; tokenId: string }
+    | { ok: false; reason: 'invalid' | 'expired' | 'revoked' | 'used' }
+  > {
+    const tokenHash = hashToken(rawToken)
+    const token = await prisma.verificationToken.findFirst({
+      where: { tokenHash, purpose }
+    })
+
+    if (!token) {
+      return { ok: false, reason: 'invalid' }
+    }
+
+    if (token.status !== 'PENDING') {
+      const reason: any = token.status.toLowerCase()
+      return { ok: false, reason }
+    }
+
+    if (new Date() > token.expiresAt) {
+      await prisma.verificationToken.update({
+        where: { id: token.id },
+        data: { status: 'EXPIRED' }
+      })
+      return { ok: false, reason: 'expired' }
+    }
+
+    return { ok: true, userId: token.userId, tokenId: token.id }
+  }
+
+  async markTokenAsUsed(tokenId: string): Promise<void> {
+    await prisma.verificationToken.update({
+      where: { id: tokenId },
+      data: { status: 'USED', usedAt: new Date() }
+    })
+  }
+
+  async revokeToken(tokenId: string): Promise<void> {
+    await prisma.verificationToken.update({
+      where: { id: tokenId },
+      data: { status: 'REVOKED' }
+    })
+  }
+
+  async revokeAllPendingTokens(userId: string, purpose: TokenPurpose): Promise<void> {
+    await prisma.verificationToken.updateMany({
+      where: { userId, purpose, status: 'PENDING' },
+      data: { status: 'REVOKED' }
+    })
+  }
+}
+
+export const tokenService = new TokenService()

--- a/tests/unit/auth/refresh-session.service.test.ts
+++ b/tests/unit/auth/refresh-session.service.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RefreshSessionService, hashToken } from '../../../src/domain/auth'
+import prisma from '../../../src/config/database'
+
+vi.mock('../../../src/config/database', () => ({
+  default: {
+    refreshSession: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+describe('RefreshSessionService', () => {
+  let service: RefreshSessionService
+
+  beforeEach(() => {
+    service = new RefreshSessionService()
+    vi.clearAllMocks()
+  })
+
+  describe('createSession', () => {
+    it('creates a session and returns raw token (not stored)', async () => {
+      ;(prisma.refreshSession.create as any).mockResolvedValue({ id: 's1' })
+
+      const result = await service.createSession('u1', {
+        userAgent: 'test-agent',
+        ipAddress: '127.0.0.1',
+      })
+
+      expect(result.rawToken).toBeTruthy()
+      expect(result.sessionId).toBe('s1')
+      expect(prisma.refreshSession.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'u1',
+            tokenHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+            userAgent: 'test-agent',
+            ipAddress: '127.0.0.1',
+          }),
+        })
+      )
+    })
+  })
+
+  describe('rotateSession', () => {
+    it('revokes old session and creates new one on successful rotation', async () => {
+      const oldToken = 'old-token'
+      const oldHash = hashToken(oldToken)
+      const oldSession = {
+        id: 's1',
+        userId: 'u1',
+        tokenHash: oldHash,
+        tokenFamily: 'fam1',
+        status: 'ACTIVE',
+        expiresAt: new Date(Date.now() + 3600000),
+      }
+
+      ;(prisma.refreshSession.findFirst as any).mockResolvedValue(oldSession)
+      ;(prisma.refreshSession.update as any).mockResolvedValue({})
+      ;(prisma.refreshSession.updateMany as any).mockResolvedValue({ count: 0 })
+      ;(prisma.refreshSession.create as any).mockResolvedValue({ id: 's2' })
+
+      const result = await service.rotateSession(oldToken)
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.userId).toBe('u1')
+        expect(result.newSessionId).toBe('s2')
+      }
+      expect(prisma.refreshSession.update).toHaveBeenCalledWith({
+        where: { id: 's1' },
+        data: { status: 'REVOKED', revokedAt: expect.any(Date) },
+      })
+    })
+
+    it('returns invalid for non-existent token', async () => {
+      ;(prisma.refreshSession.findFirst as any).mockResolvedValue(null)
+
+      const result = await service.rotateSession('invalid-token')
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toBe('invalid')
+    })
+  })
+})

--- a/tests/unit/auth/token.service.test.ts
+++ b/tests/unit/auth/token.service.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TokenService, hashToken, generateRawToken, TOKEN_LENGTH } from '../../../src/domain/auth'
+import prisma from '../../../src/config/database'
+
+vi.mock('../../../src/config/database', () => ({
+  default: {
+    verificationToken: {
+      updateMany: vi.fn(),
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+describe('token utils', () => {
+  it('generates a raw token of expected length', () => {
+    const token = generateRawToken()
+    expect(typeof token).toBe('string')
+    expect(token.length).toBe(TOKEN_LENGTH * 2) // hex encoding doubles bytes
+  })
+
+  it('hashes a token deterministically', () => {
+    const token = 'test-token'
+    const hash1 = hashToken(token)
+    const hash2 = hashToken(token)
+    expect(hash1).toEqual(hash2)
+    expect(hash1).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe('TokenService', () => {
+  let tokenService: TokenService
+
+  beforeEach(() => {
+    tokenService = new TokenService()
+    vi.clearAllMocks()
+  })
+
+  describe('createToken', () => {
+    it('revokes existing pending tokens and creates a new one', async () => {
+      const mockId = 'token-123'
+      ;(prisma.verificationToken.updateMany as any).mockResolvedValue({ count: 1 })
+      ;(prisma.verificationToken.create as any).mockResolvedValue({ id: mockId })
+
+      const result = await tokenService.createToken('user-1', 'EMAIL_VERIFICATION')
+
+      expect(result.rawToken).toBeTruthy()
+      expect(result.tokenId).toBe(mockId)
+      expect(prisma.verificationToken.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', purpose: 'EMAIL_VERIFICATION', status: 'PENDING' },
+        data: { status: 'REVOKED' },
+      })
+      expect(prisma.verificationToken.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-1',
+            tokenHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+            purpose: 'EMAIL_VERIFICATION',
+            expiresAt: expect.any(Date),
+          }),
+        })
+      )
+    })
+
+    it('never stores the raw token', async () => {
+      ;(prisma.verificationToken.updateMany as any).mockResolvedValue({ count: 0 })
+      ;(prisma.verificationToken.create as any).mockResolvedValue({ id: 't1' })
+
+      const result = await tokenService.createToken('u1', 'PASSWORD_RESET')
+      const createCall = (prisma.verificationToken.create as any).mock.calls[0][0]
+      expect(createCall.data.tokenHash).not.toBe(result.rawToken)
+    })
+  })
+
+  describe('verifyToken', () => {
+    it('returns invalid for non-existent token', async () => {
+      ;(prisma.verificationToken.findFirst as any).mockResolvedValue(null)
+      const rawToken = 'any-token'
+
+      const result = await tokenService.verifyToken(rawToken, 'EMAIL_VERIFICATION')
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toBe('invalid')
+    })
+
+    it('returns revoked for already revoked tokens', async () => {
+      const rawToken = 'some-token'
+      ;(prisma.verificationToken.findFirst as any).mockResolvedValue({
+        id: 't1',
+        userId: 'u1',
+        status: 'REVOKED',
+        expiresAt: new Date(Date.now() + 3600000),
+      })
+
+      const result = await tokenService.verifyToken(rawToken, 'EMAIL_VERIFICATION')
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toBe('revoked')
+    })
+
+    it('returns expired and marks status when token is expired', async () => {
+      const rawToken = 'token'
+      ;(prisma.verificationToken.findFirst as any).mockResolvedValue({
+        id: 't1',
+        userId: 'u1',
+        status: 'PENDING',
+        expiresAt: new Date(Date.now() - 1000),
+      })
+      ;(prisma.verificationToken.update as any).mockResolvedValue({})
+
+      const result = await tokenService.verifyToken(rawToken, 'PASSWORD_RESET')
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toBe('expired')
+      expect(prisma.verificationToken.update).toHaveBeenCalledWith({
+        where: { id: 't1' },
+        data: { status: 'EXPIRED' },
+      })
+    })
+
+    it('returns ok for valid pending token', async () => {
+      const rawToken = 'valid-token'
+      const tokenHash = hashToken(rawToken)
+      ;(prisma.verificationToken.findFirst as any).mockResolvedValue({
+        id: 't1',
+        userId: 'u1',
+        status: 'PENDING',
+        expiresAt: new Date(Date.now() + 3600000),
+      })
+
+      const result = await tokenService.verifyToken(rawToken, 'EMAIL_VERIFICATION')
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.userId).toBe('u1')
+        expect(result.tokenId).toBe('t1')
+      }
+    })
+  })
+
+  describe('markTokenAsUsed', () => {
+    it('updates token to used status', async () => {
+      ;(prisma.verificationToken.update as any).mockResolvedValue({})
+      await tokenService.markTokenAsUsed('t1')
+      expect(prisma.verificationToken.update).toHaveBeenCalledWith({
+        where: { id: 't1' },
+        data: { status: 'USED', usedAt: expect.any(Date) },
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Add Prisma models: VerificationToken (updated), RefreshSession, LoginAttempt
- Add enums: TokenPurpose, TokenStatus, SessionStatus, LoginAttemptStatus, AccountStatus
- Create src/domain/auth services for token, refresh session, and login attempt management
- Write unit tests for all new functionality

Closes #76 